### PR TITLE
docs: add PR, ISSUE templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: "🐛 버그 리포트"
+about: 재현 가능한 버그 또는 Regression
+title: 'bug: '
+labels: 'status: Unconfirmed'
+
+---
+
+<!--
+  Please provide a clear and concise description of what the bug is. Include
+  screenshots if needed. Please test using the latest version of the relevant
+  React packages to make sure your issue has not already been fixed.
+-->
+
+wtb-server version:
+
+## 버그 재현 절차
+
+1.
+2.
+
+<!--
+  Your bug will get fixed much faster if we can run your code and it doesn't
+  have dependencies other than React. Issues without reproduction steps or
+  code examples may be immediately closed as not actionable.
+-->
+
+예제 코드 링크:
+
+<!--
+  Please provide a CodeSandbox (https://codesandbox.io/s/new), a link to a
+  repository on GitHub, or provide a minimal code example that reproduces the
+  problem. You may provide a screenshot of the application if you think it is
+  relevant to your bug report. Here are some tips for providing a minimal
+  example: https://stackoverflow.com/help/mcve.
+-->
+
+## 현재 동작
+
+
+## 예상 동작

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## 제목
+
+ex. feat: 로그인 버튼 추가
+
+Commit type을 prefix로 작성
+| Commit type | 설명                                                 |
+|-------------|------------------------------------------------------|
+| feat        | 새로운 기능                                          |
+| fix         | 버그 수정                                            |
+| ci          | CI 설정 변경                                         |
+| docs        | 문서 수정                                            |
+| style       | 코드 스타일 변경 (ex. formatting, white-space)        |
+| refactor    | 리팩토링                                             |
+| test        | 테스트 추가, 수정                                     |
+| chore       | 기타 (ex. package manager configs)                   |
+
+## 해결하려는 문제가 무엇인가요?
+*
+
+## 어떻게 해결했나요?
+*
+
+## Attachment
+* 리뷰어의 이해를 도울 수 있는 자료들
+* 사진, 영상, 참고 링크

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ### 2. Pull Request를 통해 참여하는 방법
 
-[PR 템플릿](https://github.com/wtb-kr/wtb-server/blob/main/PULL_REQUEST_TEMPLATE.md)
+[PR 템플릿](https://github.com/wtb-kr/wtb-server/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
 
 #### 1. Fork this repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# How to Contribute
+
+### 1. 버그 제보하는 방법
+
+[버그 리포트 안내](https://github.com/wtb-kr/wtb-server/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
+
+[Issues 탭]에서 이슈로 등록해주시면 함께 논의해보고 반영할 수 있습니다.
+
+### 2. Pull Request를 통해 참여하는 방법
+
+[PR 템플릿](https://github.com/wtb-kr/wtb-server/blob/main/PULL_REQUEST_TEMPLATE.md)
+
+#### 1. Fork this repository
+
+#### 2. Clone forked repository
+
+#### 3. Commit your work
+
+#### 4. Register pull request for your commit


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?

PR 템플릿 통일하기
코드 리뷰를 쉽게 할 수 있게 만들기

## 어떻게 해결했나요?

Commit type을 제목의 접두사로 넣습니다
(제목만 보아도 어떤 PR인지 파악할 수 있어야 합니다)

하나의 PR은 하나의 type만 갖는 작은 단위로 유지합니다

리뷰어가 쉽게 코드를 이해할 수 있도록 해결한 방법을 설명하고 참고 자료를 넣습니다

## Attachment

커밋 타입
http://udacity.github.io/git-styleguide/

PR 템플릿
https://techblog.woowahan.com/7152/

이슈 템플릿
https://github.com/facebook/react/tree/main/.github
